### PR TITLE
Add Model Count + Model Observations metrics to scheduler

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -72,13 +72,13 @@ public class PrometheusPublisher {
         values.put(id, new AtomicDouble(value));
         final Iterable<Tag> tags = generateTags(modelName, id, request);
         createOrUpdateGauge(METRIC_PREFIX + request.getMetricName().toLowerCase(), tags, id);
-        LOG.info(String.format("Scheduled request for %s id=%s, value=%f", request.getMetricName(), id, value));
+        LOG.debug(String.format("Scheduled request for %s id=%s, value=%f", request.getMetricName(), id, value));
     }
 
     public void gauge(String modelName, String metricName, UUID id, double value) {
         values.put(id, new AtomicDouble(value));
         final Iterable<Tag> tags = generateTags(modelName, id, null);
         createOrUpdateGauge(METRIC_PREFIX + metricName.toLowerCase(), tags, id);
-        LOG.info(String.format("Scheduled request for %s id=%s, value=%f", metricName, id, value));
+        LOG.debug(String.format("Scheduled request for %s id=%s, value=%f", metricName, id, value));
     }
 }

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusPublisher.java
@@ -18,7 +18,6 @@ import org.kie.trustyai.service.validators.metrics.ValidReconciledMetricRequest;
 
 import com.google.common.util.concurrent.AtomicDouble;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -44,7 +43,6 @@ public class PrometheusPublisher {
         Gauge.builder(name, new AtomicDouble(), value -> values.get(id).doubleValue())
                 .tags(tags).strongReference(true).register(registry);
     }
-
 
     public void removeGauge(String name, UUID id) {
         Search s = this.registry.find(METRIC_PREFIX + name.toLowerCase());
@@ -84,5 +82,3 @@ public class PrometheusPublisher {
         LOG.info(String.format("Scheduled request for %s id=%s, value=%f", metricName, id, value));
     }
 }
-
-

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -32,7 +32,6 @@ public class PrometheusScheduler {
     @Inject
     protected PrometheusPublisher publisher;
 
-
     @Inject
     ServiceConfig serviceConfig;
 

--- a/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/prometheus/PrometheusScheduler.java
@@ -1,5 +1,6 @@
 package org.kie.trustyai.service.prometheus;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -31,6 +32,7 @@ public class PrometheusScheduler {
     @Inject
     PrometheusPublisher publisher;
 
+
     @Inject
     ServiceConfig serviceConfig;
 
@@ -58,12 +60,17 @@ public class PrometheusScheduler {
 
     @Scheduled(every = "{service.metrics-schedule}")
     void calculate() {
+        try {
+            // global service statistic
+            DataSource ds = dataSource.get();
+            publisher.gauge("", "MODEL_COUNT", UUID.nameUUIDFromBytes("model_count".getBytes(StandardCharsets.UTF_8)), ds.getKnownModels().size());
 
-        if (hasRequests()) {
+            Set<String> requestedModels = getModelIds();
+            for (final String modelId : ds.getKnownModels()) {
+                // global model statistics
+                publisher.gauge(modelId, "MODEL_OBSERVATIONS", UUID.nameUUIDFromBytes(modelId.getBytes(StandardCharsets.UTF_8)), ds.getMetadata(modelId).getObservations());
 
-            try {
-                for (final String modelId : getModelIds()) {
-
+                if (hasRequests() && requestedModels.contains(modelId)) {
                     final Predicate<Map.Entry<UUID, BaseMetricRequest>> filterByModelId = request -> request.getValue().getModelId().equals(modelId);
                     List<Map.Entry<UUID, BaseMetricRequest>> requestsSet = getAllRequestsFlat().entrySet().stream().filter(filterByModelId).collect(Collectors.toList());
 
@@ -71,8 +78,7 @@ public class PrometheusScheduler {
                     final int maxBatchSize = requestsSet.stream()
                             .mapToInt(entry -> entry.getValue().getBatchSize()).max()
                             .orElse(serviceConfig.batchSize().getAsInt());
-
-                    final Dataframe df = dataSource.get().getDataframe(modelId, maxBatchSize);
+                    final Dataframe df = ds.getDataframe(modelId, maxBatchSize);
 
                     requestsSet.forEach(entry -> {
                         // entry value: BaseMetricRequest
@@ -83,11 +89,12 @@ public class PrometheusScheduler {
                         publisher.gauge(entry.getValue(), modelId, entry.getKey(), value);
                     });
                 }
-            } catch (DataframeCreateException e) {
-                LOG.error(e.getMessage());
             }
+        } catch (DataframeCreateException e) {
+            LOG.error(e.getMessage());
         }
     }
+
 
     public PrometheusPublisher getPublisher() {
         return publisher;


### PR DESCRIPTION
Adds two metrics that are always included in the PrometheusScheduler:

- trustyai_model_count: the number of models registered with TrustyAI
- trustyai_model_observations: the number of observations, by model

Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `FAI-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.3.x] FAI-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

