### PR TITLE
refactor: Use separate workflow for Trivy scans

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -151,19 +151,4 @@ jobs:
                   sourcePath: ''
                   uri: https://api.github.com/repos/trustyai-explainability/trustyai-service-operator-ci/tarball/service-${{ env.TAG }}
             ```
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'MEDIUM,HIGH,CRITICAL'
-          exit-code: '0'
-          ignore-unfixed: false
-          vuln-type: 'os,library'
 
-      - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,37 @@
+name: Trivy Security Scan
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+
+      - name: Update Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif' 


### PR DESCRIPTION
## Summary by Sourcery

Separate the Trivy vulnerability scan into its own GitHub Actions workflow and remove it from the build-and-push pipeline.

CI:
- Extract Trivy scan steps from build-and-push workflow into a dedicated trivy-scan.yaml file
- Configure the new workflow to run on pushes to main, version tags, and pull request events
- Grant the trivy-scan job read permissions for repo contents and write permissions for pull requests and security events