### PR TITLE
refactor: Upgrade from OptaPlanner 8.30.0 to Timefold Solver 1.26.1

### DIFF
--- a/explainability-arrow/pom.xml
+++ b/explainability-arrow/pom.xml
@@ -114,13 +114,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>org.optaplanner:optaplanner-constraint-streams</exclude>
-                                </excludes>
-                            </artifactSet>
-                        </configuration>
                         <executions>
                             <execution>
                                 <phase>package</phase>

--- a/explainability-core/pom.xml
+++ b/explainability-core/pom.xml
@@ -38,26 +38,8 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-core</artifactId>
-      <exclusions>
-        <!--
-          Removes all dependencies on OptaPlanner Drools, as Trusty does not use it.
-          This prevents diamond dependency on Drools between OptaPlanner and Kogito.
-        -->
-        <exclusion>
-          <groupId>org.optaplanner</groupId>
-          <artifactId>optaplanner-constraint-streams-drools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.optaplanner</groupId>
-          <artifactId>optaplanner-constraint-drl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.drools</groupId>
-          <artifactId>drools-wiring-static</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>ai.timefold.solver</groupId>
+      <artifactId>timefold-solver-core</artifactId>
     </dependency>
 
     <dependency>

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualConfig.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualConfig.java
@@ -20,9 +20,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
-import org.optaplanner.core.api.solver.SolverManager;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.SolverManagerConfig;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.SolverManagerConfig;
 
 /**
  * Counterfactual explainer configuration parameters.

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualSolution.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualSolution.java
@@ -23,13 +23,14 @@ import org.kie.trustyai.explainability.local.counterfactual.goal.CounterfactualG
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.explainability.model.PredictionProvider;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningScore;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 
 /**
- * Represents an OptaPlanner {@link PlanningSolution}.
+ * Represents an Timefold Solver {@link PlanningSolution}.
  * This solution stores all the features as {@link CounterfactualEntity}, as well as a reference to the
  * {@link PredictionProvider} model.
  */

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/SolverConfigBuilder.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/SolverConfigBuilder.java
@@ -32,13 +32,14 @@ import org.kie.trustyai.explainability.local.counterfactual.entities.TimeEntity;
 import org.kie.trustyai.explainability.local.counterfactual.entities.URIEntity;
 import org.kie.trustyai.explainability.local.counterfactual.score.CounterfactualScoreCalculator;
 import org.kie.trustyai.explainability.local.counterfactual.score.DefaultCounterfactualScoreCalculator;
-import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
-import org.optaplanner.core.config.localsearch.decider.acceptor.LocalSearchAcceptorConfig;
-import org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
-import org.optaplanner.core.config.phase.PhaseConfig;
-import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import ai.timefold.solver.core.config.localsearch.LocalSearchPhaseConfig;
+import ai.timefold.solver.core.config.localsearch.decider.acceptor.LocalSearchAcceptorConfig;
+import ai.timefold.solver.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
+import ai.timefold.solver.core.config.phase.PhaseConfig;
+import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 public class SolverConfigBuilder {
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/AbstractCategoricalEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/AbstractCategoricalEntity.java
@@ -21,13 +21,12 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
 
 /**
- * Abstract categorical feature an OptaPlanner {@link PlanningEntity}
+ * Abstract categorical feature an Timefold Solver {@link PlanningEntity}
  */
-@PlanningEntity
 public abstract class AbstractCategoricalEntity<T> extends AbstractEntity<T> {
 
     protected Set<T> allowedCategories;

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/AbstractEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/AbstractEntity.java
@@ -15,11 +15,13 @@
  */
 package org.kie.trustyai.explainability.local.counterfactual.entities;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import org.kie.trustyai.explainability.model.Feature;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.impl.domain.valuerange.buildin.composite.EmptyValueRange;
+
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
  * Common class for counterfactual entities
@@ -71,7 +73,7 @@ public abstract class AbstractEntity<T> implements CounterfactualEntity {
 
     @Override
     public ValueRange getValueRange() {
-        return new EmptyValueRange<>();
+        return new ListValueRange<>(Collections.emptyList());
     }
 
     @Override

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/BinaryEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/BinaryEntity.java
@@ -21,15 +21,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a binary categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a binary categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class BinaryEntity extends AbstractCategoricalEntity<ByteBuffer> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/BooleanEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/BooleanEntity.java
@@ -19,15 +19,16 @@ import java.util.Objects;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between a boolean feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a boolean feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class BooleanEntity extends AbstractEntity<Boolean> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CategoricalEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CategoricalEntity.java
@@ -20,15 +20,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class CategoricalEntity extends AbstractCategoricalEntity<String> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CategoricalNumericalEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CategoricalNumericalEntity.java
@@ -20,15 +20,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a numerical categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a numerical categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class CategoricalNumericalEntity extends AbstractCategoricalEntity<Integer> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CounterfactualEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CounterfactualEntity.java
@@ -16,7 +16,8 @@
 package org.kie.trustyai.explainability.local.counterfactual.entities;
 
 import org.kie.trustyai.explainability.model.Feature;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
+
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
 
 public interface CounterfactualEntity {
     public double distance();

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CurrencyEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/CurrencyEntity.java
@@ -21,15 +21,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a currency categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a currency categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class CurrencyEntity extends AbstractCategoricalEntity<Currency> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/DoubleEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/DoubleEntity.java
@@ -17,15 +17,16 @@ package org.kie.trustyai.explainability.local.counterfactual.entities;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureDistribution;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between a Double feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a Double feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class DoubleEntity extends AbstractNumericEntity<Double> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/DurationEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/DurationEntity.java
@@ -20,15 +20,16 @@ import java.time.Duration;
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureDistribution;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between a Duration feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a Duration feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class DurationEntity extends AbstractAlgebraicEntity<Duration> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/IntegerEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/IntegerEntity.java
@@ -17,15 +17,16 @@ package org.kie.trustyai.explainability.local.counterfactual.entities;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureDistribution;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between an integer feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between an integer feature an Timefold Solver {@link PlanningEntity}
  */
 
 @PlanningEntity

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/LongEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/LongEntity.java
@@ -17,15 +17,16 @@ package org.kie.trustyai.explainability.local.counterfactual.entities;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureDistribution;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between a {@link Long} feature and an OptaPlanner {@link PlanningEntity}
+ * Mapping between a {@link Long} feature and an Timefold Solver {@link PlanningEntity}
  */
 
 @PlanningEntity

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/ObjectEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/ObjectEntity.java
@@ -20,15 +20,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class ObjectEntity extends AbstractCategoricalEntity<Object> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/TextEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/TextEntity.java
@@ -20,15 +20,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class TextEntity extends AbstractCategoricalEntity<String> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/TimeEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/TimeEntity.java
@@ -21,15 +21,16 @@ import java.time.temporal.ChronoUnit;
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureDistribution;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 /**
- * Mapping between a Duration feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a Duration feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class TimeEntity extends AbstractAlgebraicEntity<LocalTime> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/URIEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/entities/URIEntity.java
@@ -21,15 +21,16 @@ import java.util.Set;
 
 import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.FeatureFactory;
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.entity.PlanningPin;
-import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.valuerange.buildin.collection.ListValueRange;
+
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPin;
+import ai.timefold.solver.core.api.domain.valuerange.CountableValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.impl.domain.valuerange.buildin.collection.ListValueRange;
 
 /**
- * Mapping between a categorical feature an OptaPlanner {@link PlanningEntity}
+ * Mapping between a categorical feature an Timefold Solver {@link PlanningEntity}
  */
 @PlanningEntity
 public class URIEntity extends AbstractCategoricalEntity<URI> {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/CounterfactualScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/CounterfactualScoreCalculator.java
@@ -17,8 +17,9 @@
 package org.kie.trustyai.explainability.local.counterfactual.score;
 
 import org.kie.trustyai.explainability.local.counterfactual.CounterfactualSolution;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 
 public interface CounterfactualScoreCalculator extends EasyScoreCalculator<CounterfactualSolution, BendableBigDecimalScore> {
 }

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/counterfactual/score/DefaultCounterfactualScoreCalculator.java
@@ -33,9 +33,10 @@ import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.explainability.model.PredictionProvider;
 import org.kie.trustyai.explainability.utils.CompositeFeatureUtils;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 
 /**
  * Counterfactual score calculator.

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/BooleanLimeConfigEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/BooleanLimeConfigEntity.java
@@ -15,11 +15,11 @@
  */
 package org.kie.trustyai.explainability.local.lime.optim;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
 public class BooleanLimeConfigEntity extends LimeConfigEntity {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeCombinedScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeCombinedScoreCalculator.java
@@ -15,8 +15,8 @@
  */
 package org.kie.trustyai.explainability.local.lime.optim;
 
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 
 /**
  * A score calculator which combines stability and impact-score scores.

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeConfigOptimizer.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeConfigOptimizer.java
@@ -25,20 +25,21 @@ import java.util.concurrent.ExecutionException;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionProvider;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
-import org.optaplanner.core.api.solver.SolverJob;
-import org.optaplanner.core.api.solver.SolverManager;
-import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
-import org.optaplanner.core.config.localsearch.LocalSearchType;
-import org.optaplanner.core.config.phase.PhaseConfig;
-import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.SolverManagerConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.localsearch.LocalSearchPhaseConfig;
+import ai.timefold.solver.core.config.localsearch.LocalSearchType;
+import ai.timefold.solver.core.config.phase.PhaseConfig;
+import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.SolverManagerConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 public class LimeConfigOptimizer {
 
@@ -187,7 +188,7 @@ public class LimeConfigOptimizer {
                 // Wait until the solving ends
                 LimeConfigSolution finalBestSolution = solverJob.getFinalBestSolution();
                 LimeConfig finalConfig = LimeConfigEntityFactory.toLimeConfig(finalBestSolution);
-                BigDecimal score = finalBestSolution.getScore().getScore();
+                BigDecimal score = finalBestSolution.getScore().score();
                 logger.info("final best solution score {} with config {}", score, finalConfig);
                 return finalConfig;
             } catch (ExecutionException e) {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeConfigSolution.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeConfigSolution.java
@@ -21,10 +21,11 @@ import java.util.List;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionProvider;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningScore;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+import ai.timefold.solver.core.api.domain.solution.PlanningEntityCollectionProperty;
+import ai.timefold.solver.core.api.domain.solution.PlanningScore;
+import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 
 @PlanningSolution
 public class LimeConfigSolution {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeImpactScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeImpactScoreCalculator.java
@@ -29,10 +29,11 @@ import org.kie.trustyai.explainability.model.FeatureImportance;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.Saliency;
 import org.kie.trustyai.metrics.explainability.ExplainabilityMetrics;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 
 public class LimeImpactScoreCalculator implements EasyScoreCalculator<LimeConfigSolution, SimpleBigDecimalScore> {
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeStabilityScoreCalculator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/LimeStabilityScoreCalculator.java
@@ -27,10 +27,11 @@ import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionProvider;
 import org.kie.trustyai.explainability.utils.LocalSaliencyStability;
 import org.kie.trustyai.metrics.explainability.ExplainabilityMetrics;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 
 public class LimeStabilityScoreCalculator implements EasyScoreCalculator<LimeConfigSolution, SimpleBigDecimalScore> {
 

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/NumericLimeConfigEntity.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/lime/optim/NumericLimeConfigEntity.java
@@ -15,11 +15,11 @@
  */
 package org.kie.trustyai.explainability.local.lime.optim;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.api.domain.valuerange.ValueRange;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
-import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRange;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeFactory;
+import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
+import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
 
 @PlanningEntity
 public class NumericLimeConfigEntity extends LimeConfigEntity {

--- a/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGenerator.java
+++ b/explainability-core/src/main/java/org/kie/trustyai/explainability/local/shap/background/CounterfactualGenerator.java
@@ -47,8 +47,9 @@ import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.explainability.utils.DataUtils;
 import org.kie.trustyai.explainability.utils.MatrixUtilsExtensions;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 public class CounterfactualGenerator {
     private final Integer kSeeds;

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -66,14 +66,15 @@ import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
 import org.kie.trustyai.explainability.utils.DataUtils;
 import org.kie.trustyai.explainability.utils.models.TestModels;
 import org.mockito.ArgumentCaptor;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
-import org.optaplanner.core.api.solver.SolverJob;
-import org.optaplanner.core.api.solver.SolverManager;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import ai.timefold.solver.core.api.solver.SolverJob;
+import ai.timefold.solver.core.api.solver.SolverManager;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -639,7 +640,7 @@ class CounterfactualExplainerTest {
         ArgumentCaptor<Consumer<CounterfactualSolution>> intermediateSolutionConsumerCaptor =
                 ArgumentCaptor.forClass(Consumer.class);
         CounterfactualResult result = mockExplainerInvocation(captureSequenceIds, null);
-        verify(solverManager).solveAndListen(any(), any(), intermediateSolutionConsumerCaptor.capture(), any());
+        verify(solverManager).solveBuilder().withProblemId(any()).withProblemFinder(any()).withBestSolutionConsumer(intermediateSolutionConsumerCaptor.capture()).withExceptionHandler(any()).run();
         Consumer<CounterfactualSolution> intermediateSolutionConsumer = intermediateSolutionConsumerCaptor.getValue();
 
         //Mock the intermediate Solution callback being invoked
@@ -855,7 +856,7 @@ class CounterfactualExplainerTest {
         SolverJob<CounterfactualSolution, UUID> solverJob = mock(SolverJob.class);
         CounterfactualSolution solution = mock(CounterfactualSolution.class);
         BendableBigDecimalScore score = BendableBigDecimalScore.zero(0, 0);
-        when(solverManager.solveAndListen(any(), any(), any(), any())).thenReturn(solverJob);
+        when(solverManager.solveBuilder().withProblemId(any()).withProblemFinder(any()).withBestSolutionConsumer(any()).withExceptionHandler(any()).run()).thenReturn(solverJob);
         when(solverJob.getFinalBestSolution()).thenReturn(solution);
         when(solution.getScore()).thenReturn(score);
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -49,7 +49,8 @@ import org.kie.trustyai.explainability.model.domain.EmptyFeatureDomain;
 import org.kie.trustyai.explainability.model.domain.FeatureDomain;
 import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
 import org.kie.trustyai.explainability.utils.models.TestModels;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1105,11 +1106,11 @@ class CounterfactualScoreCalculatorTest {
         assertEquals(2, goal.size());
         assertEquals(1, predictionOutputs.size()); // A single prediction is expected
         assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
-        assertEquals(0, score.getHardScore(0).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getHardScore(1).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getHardScore(2).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getSoftScore(0).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getSoftScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(2).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.softScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.softScore(1).compareTo(BigDecimal.ZERO));
         assertEquals(3, score.getHardLevelsSize());
         assertEquals(2, score.getSoftLevelsSize());
     }
@@ -1250,11 +1251,11 @@ class CounterfactualScoreCalculatorTest {
         assertEquals(2, goal.size());
         assertEquals(1, predictionOutputs.size()); // A single prediction is expected
         assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
-        assertEquals(0, score.getHardScore(0).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getHardScore(1).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getHardScore(2).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getSoftScore(0).compareTo(BigDecimal.ZERO));
-        assertEquals(0, score.getSoftScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.hardScore(2).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.softScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.softScore(1).compareTo(BigDecimal.ZERO));
         assertEquals(3, score.getHardLevelsSize());
         assertEquals(2, score.getSoftLevelsSize());
     }
@@ -1371,7 +1372,7 @@ class CounterfactualScoreCalculatorTest {
 
         final BendableBigDecimalScore score = scoreCalculator.calculateScore(solution);
 
-        assertEquals(0.0, score.getSoftScore(0).doubleValue(), 1e-5);
+        assertEquals(0.0, score.softScore(0).doubleValue(), 1e-5);
     }
 
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualUtils.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/CounterfactualUtils.java
@@ -31,9 +31,10 @@ import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionInput;
 import org.kie.trustyai.explainability.model.PredictionOutput;
 import org.kie.trustyai.explainability.model.PredictionProvider;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 public class CounterfactualUtils {
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/score/MockCounterFactualScoreCalculator.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/counterfactual/score/MockCounterFactualScoreCalculator.java
@@ -18,8 +18,9 @@ package org.kie.trustyai.explainability.local.counterfactual.score;
 import java.math.BigDecimal;
 
 import org.kie.trustyai.explainability.local.counterfactual.CounterfactualSolution;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
-import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+
+import ai.timefold.solver.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import ai.timefold.solver.core.api.score.calculator.EasyScoreCalculator;
 
 /**
  * Mock score calculation class which guarantees an increasing soft score with each call

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeCombinedScoreCalculatorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeCombinedScoreCalculatorTest.java
@@ -26,7 +26,8 @@ import org.kie.trustyai.explainability.Config;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.explainability.utils.models.TestModels;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -42,7 +43,7 @@ class LimeCombinedScoreCalculatorTest {
         LimeConfigSolution solution = new LimeConfigSolution(config, predictions, entities, model);
         SimpleBigDecimalScore score = scoreCalculator.calculateScore(solution);
         assertThat(score).isNotNull();
-        assertThat(score.getScore()).isNotNull().isEqualTo(BigDecimal.valueOf(0));
+        assertThat(score.score()).isNotNull().isEqualTo(BigDecimal.valueOf(0));
     }
 
     @Test
@@ -63,7 +64,7 @@ class LimeCombinedScoreCalculatorTest {
         LimeConfigSolution solution = new LimeConfigSolution(config, predictions, entities, model);
         SimpleBigDecimalScore score = scoreCalculator.calculateScore(solution);
         assertThat(score).isNotNull();
-        assertThat(score.getScore()).isNotNull().isNotEqualTo(BigDecimal.valueOf(0));
+        assertThat(score.score()).isNotNull().isNotEqualTo(BigDecimal.valueOf(0));
     }
 
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeImpactScoreCalculatorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeImpactScoreCalculatorTest.java
@@ -26,7 +26,8 @@ import org.kie.trustyai.explainability.Config;
 import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.model.*;
 import org.kie.trustyai.explainability.utils.models.TestModels;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -42,7 +43,7 @@ class LimeImpactScoreCalculatorTest {
         LimeConfigSolution solution = new LimeConfigSolution(config, predictions, entities, model);
         SimpleBigDecimalScore score = scoreCalculator.calculateScore(solution);
         assertThat(score).isNotNull();
-        assertThat(score.getScore()).isNotNull().isEqualTo(BigDecimal.valueOf(0));
+        assertThat(score.score()).isNotNull().isEqualTo(BigDecimal.valueOf(0));
     }
 
     @Test
@@ -63,7 +64,7 @@ class LimeImpactScoreCalculatorTest {
         LimeConfigSolution solution = new LimeConfigSolution(config, predictions, entities, model);
         SimpleBigDecimalScore score = scoreCalculator.calculateScore(solution);
         assertThat(score).isNotNull();
-        assertThat(score.getScore()).isNotNull().isNotEqualTo(BigDecimal.valueOf(0));
+        assertThat(score.score()).isNotNull().isNotEqualTo(BigDecimal.valueOf(0));
     }
 
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeStabilityScoreCalculatorTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/local/lime/optim/LimeStabilityScoreCalculatorTest.java
@@ -24,7 +24,8 @@ import org.kie.trustyai.explainability.local.lime.LimeConfig;
 import org.kie.trustyai.explainability.model.Prediction;
 import org.kie.trustyai.explainability.model.PredictionProvider;
 import org.kie.trustyai.explainability.utils.models.TestModels;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+
+import ai.timefold.solver.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -40,7 +41,7 @@ class LimeStabilityScoreCalculatorTest {
         LimeConfigSolution solution = new LimeConfigSolution(config, predictions, entities, model);
         SimpleBigDecimalScore score = scoreCalculator.calculateScore(solution);
         assertThat(score).isNotNull();
-        assertThat(score.getScore()).isNotNull();
-        assertThat(score.getScore()).isEqualTo(BigDecimal.valueOf(0));
+        assertThat(score.score()).isNotNull();
+        assertThat(score.score()).isEqualTo(BigDecimal.valueOf(0));
     }
 }

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/IOUtilsTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/IOUtilsTest.java
@@ -9,7 +9,7 @@ import org.kie.trustyai.explainability.model.Feature;
 import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.model.Value;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class IOUtilsTest {
 

--- a/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/LassoLarsICTest.java
+++ b/explainability-core/src/test/java/org/kie/trustyai/explainability/utils/LassoLarsICTest.java
@@ -20,7 +20,8 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LassoLarsICTest {
     // check equivalent output as https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoLarsIC.html

--- a/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
+++ b/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
@@ -46,9 +46,9 @@ import org.kie.trustyai.explainability.model.PredictionProvider;
 import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/LoanEligibilityCounterfactualExplainerTest.java
+++ b/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/LoanEligibilityCounterfactualExplainerTest.java
@@ -49,9 +49,9 @@ import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
 import org.kie.trustyai.explainability.utils.CompositeFeatureUtils;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/PrequalificationDmnCounterfactualExplainerTest.java
+++ b/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/trustyai/explainability/integrationtests/dmn/PrequalificationDmnCounterfactualExplainerTest.java
@@ -48,9 +48,9 @@ import org.kie.trustyai.explainability.model.Type;
 import org.kie.trustyai.explainability.model.Value;
 import org.kie.trustyai.explainability.model.domain.NumericalFeatureDomain;
 import org.kie.trustyai.explainability.utils.CompositeFeatureUtils;
-import org.optaplanner.core.config.solver.EnvironmentMode;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import ai.timefold.solver.core.config.solver.EnvironmentMode;
+import ai.timefold.solver.core.config.solver.SolverConfig;
+import ai.timefold.solver.core.config.solver.termination.TerminationConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.org.assertj>3.22.0</version.org.assertj>
         <version.org.awaitility>4.2.0</version.org.awaitility>
 
-        <version.org.optaplanner>8.30.0.Final</version.org.optaplanner>
+        <version.ai.timefold.solver>1.26.1</version.ai.timefold.solver>
         <version.org.kie.kogito>1.30.0.Final</version.org.kie.kogito>
 
         <version.surefire.plugin>3.2.5</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
@@ -72,9 +72,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.optaplanner</groupId>
-                <artifactId>optaplanner-bom</artifactId>
-                <version>${version.org.optaplanner}</version>
+                <groupId>ai.timefold.solver</groupId>
+                <artifactId>timefold-solver-bom</artifactId>
+                <version>${version.ai.timefold.solver}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
OptaPlanner 8.30.0 was released in Nov 2022.
Timefold Solver 1.26.1 was released recently.

Timefold Solver (also Apache licensed) continued the OptaPlanner open source work and made many improvements:
- Improved performance and scalability
- More cloud friendly
- Fix security bugs and other issues

A full list of the improvements over the last 2.5 years (with more than 100 bugfixes since the OptaPlanner fork) can be found here:
https://github.com/TimefoldAI/timefold-solver/releases

