### PR TITLE
ci: Update trivy-action to version 0.35.0

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary
- Updates `aquasecurity/trivy-action` from `0.28.0` to `0.35.0`

## Problem
The current workflow references `aquasecurity/trivy-action@0.28.0`, which needs to be updated to the latest stable release to ensure compatibility with current CI infrastructure.

## Solution
Updated to version `0.35.0` (published March 7, 2026) following the same pattern as [trustyai-service PR #97](https://github.com/trustyai-explainability/trustyai-service/pull/97).

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Confirm Trivy scan completes successfully on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Bump aquasecurity/trivy-action in the Trivy scan GitHub Actions workflow from 0.28.0 to 0.35.0.