### PR TITLE
fix: Guard against null CloudEvent data buffer

### DIFF
--- a/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/endpoints/consumer/CloudEventConsumer.java
@@ -35,10 +35,17 @@ public class CloudEventConsumer {
     @CloudEventMapping(trigger = "org.kubeflow.serving.inference.request")
     public void consumeKubeflowRequest(CloudEvent<byte[]> cloudEvent) {
         LOG.debug("Received Kubeflow request with id = " + cloudEvent.id());
+        byte[] data;
+        try {
+            data = cloudEvent.data();
+        } catch (NullPointerException e) {
+            LOG.warn("CloudEvent request has no data payload, skipping id=" + cloudEvent.id());
+            return;
+        }
         final KServeInputPayload input = new KServeInputPayload();
         input.setId(cloudEvent.id());
         input.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        input.setData(new String(decompressIfGzip(cloudEvent.data()), StandardCharsets.UTF_8));
+        input.setData(new String(decompressIfGzip(data), StandardCharsets.UTF_8));
         reconciler.addUnreconciledInput(input);
     }
 
@@ -46,17 +53,24 @@ public class CloudEventConsumer {
     @CloudEventMapping(trigger = "org.kubeflow.serving.inference.response")
     public void consumeKubeflowResponse(CloudEvent<byte[]> cloudEvent) throws JsonProcessingException {
         LOG.debug("Received Kubeflow response with id = " + cloudEvent.id());
+        byte[] data;
+        try {
+            data = cloudEvent.data();
+        } catch (NullPointerException e) {
+            LOG.warn("CloudEvent response has no data payload, skipping id=" + cloudEvent.id());
+            return;
+        }
 
         final KServeOutputPayload output = new KServeOutputPayload();
         output.setId(cloudEvent.id());
         output.setModelId(cloudEvent.extensions().get("Inferenceservicename"));
-        byte[] original = decompressIfGzip(cloudEvent.data());
+        byte[] original = decompressIfGzip(data);
         String decoded = new String(original, StandardCharsets.UTF_8);
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        InferenceLoggerOutput data = objectMapper.readValue(decoded, InferenceLoggerOutput.class);
-        output.setData(data);
+        InferenceLoggerOutput loggerOutput = objectMapper.readValue(decoded, InferenceLoggerOutput.class);
+        output.setData(loggerOutput);
         reconciler.addUnreconciledOutput(output);
     }
 


### PR DESCRIPTION
## Summary

Guard against `NullPointerException` in `CloudEventConsumer` when Funqy Knative Events delivers CloudEvents with a null internal Vert.x buffer.

## Problem

`cloudEvent.data()` throws `NullPointerException: Cannot invoke "io.vertx.core.buffer.Buffer.getBytes()" because "this.buffer" is null` when the Funqy framework delivers a CloudEvent with no data payload. This is a framework-level issue — the NPE occurs inside the Funqy/Vert.x binding layer before application code can check for null.

Observed on cluster `user1-test` with KServe inference requests.

## Fix

Add try-catch guards around `cloudEvent.data()` in both `consumeKubeflowRequest` and `consumeKubeflowResponse`. On null buffer, log a warning and skip the event gracefully instead of crashing.

## Test plan

- [x] Compiles cleanly
- [x] Verified on cluster — null buffer events are logged and skipped, valid events process normally

## Related

- [RHOAIENG-66317](https://redhat.atlassian.net/browse/RHOAIENG-66317)
- PR #707 — Gzip decompression fix (separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Handle null CloudEvent data buffers in Kubeflow request and response consumers to avoid NullPointerExceptions and skip empty events safely.