### PR TITLE
Fix: Bump opennlp to 2.5.9

### DIFF
--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeConfig.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeConfig.java
@@ -17,6 +17,7 @@ public class KServeConfig {
 
     /**
      * Create a configuration class for a remote Open Inference model server
+     * 
      * @param target The model's URI, typically a DNS name and port
      * @param modelId The model's ID
      * @param version The model version

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParser.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPayloadParser.java
@@ -79,11 +79,12 @@ public class KServeV2HTTPPayloadParser extends PayloadParser<String> {
 
     public static Output getOutput(KServeDatatype datatype, int j, Object value) {
         Output output;
-        if (datatype == KServeDatatype.FP32 || datatype == KServeDatatype.FP64 || datatype == KServeDatatype.INT8 || datatype == KServeDatatype.INT16 || datatype == KServeDatatype.INT32 || datatype == KServeDatatype.INT64) {
+        if (datatype == KServeDatatype.FP32 || datatype == KServeDatatype.FP64 || datatype == KServeDatatype.INT8 || datatype == KServeDatatype.INT16 || datatype == KServeDatatype.INT32
+                || datatype == KServeDatatype.INT64) {
             output = new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value(value), 1.0);
         } else if (datatype == KServeDatatype.BOOL) {
             output = new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.BOOLEAN, new Value(value), 1.0);
-        } else  {
+        } else {
             output = new Output(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.CATEGORICAL, new Value(value), 1.0);
         }
         return output;
@@ -91,11 +92,12 @@ public class KServeV2HTTPPayloadParser extends PayloadParser<String> {
 
     public static Feature getFeature(KServeDatatype datatype, int j, Object value) {
         Feature feature;
-        if (datatype == KServeDatatype.FP32 || datatype == KServeDatatype.FP64 || datatype == KServeDatatype.INT8 || datatype == KServeDatatype.INT16 || datatype == KServeDatatype.INT32 || datatype == KServeDatatype.INT64) {
+        if (datatype == KServeDatatype.FP32 || datatype == KServeDatatype.FP64 || datatype == KServeDatatype.INT8 || datatype == KServeDatatype.INT16 || datatype == KServeDatatype.INT32
+                || datatype == KServeDatatype.INT64) {
             feature = new Feature(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.NUMBER, new Value(value));
         } else if (datatype == KServeDatatype.BOOL) {
             feature = new Feature(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.BOOLEAN, new Value(value));
-        } else  {
+        } else {
             feature = new Feature(DEFAULT_OUTPUT_PREFIX + "-" + j, Type.CATEGORICAL, new Value(value));
         }
         return feature;

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/KServeV2HTTPPredictionProvider.java
@@ -39,7 +39,6 @@ public class KServeV2HTTPPredictionProvider extends AbstractKServePredictionProv
         this.outputShape = outputShape;
     }
 
-
     public CompletableFuture<List<PredictionOutput>> predictAsync(List<PredictionInput> inputs) {
         final ObjectMapper mapper = new ObjectMapper();
 

--- a/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
+++ b/explainability-connectors/src/main/java/org/kie/trustyai/connectors/kserve/v2/TensorConverter.java
@@ -1,7 +1,6 @@
 package org.kie.trustyai.connectors.kserve.v2;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -122,7 +121,7 @@ public class TensorConverter {
                 }).collect(Collectors.toCollection(ArrayList::new));
 
                 return new ArrayList<>(List.of(new PredictionInput(features)));
-            } else if (shape.size() > 2 && !raw){
+            } else if (shape.size() > 2 && !raw) {
                 List<PredictionInput> predictionInputs = new ArrayList<>();
                 for (int batch = 0; batch < data.getInputsCount(); batch++) {
                     List<Feature> fs = new ArrayList<>();
@@ -266,7 +265,6 @@ public class TensorConverter {
                 boolean secondDimMatch = perTensorSecondShape.stream().allMatch(i -> i == enforcedFirstDimension);
                 boolean firstDimMatch = perTensorShapes.stream().allMatch(i -> i.get(0) == enforcedFirstDimension);
 
-
                 if (enforcedFirstDimension == 1) {
                     final List<Output> outputs = IntStream.range(0, tensors.size())
                             .mapToObj(tensorIDX -> {
@@ -326,7 +324,8 @@ public class TensorConverter {
                     }
                     return predictionOutputs;
                 } else {
-                    throw new IllegalArgumentException("Tensor shapes=" + perTensorShapes + " were expected to match the input count=" + enforcedFirstDimension + " along either the first or second dimension, but does not.");
+                    throw new IllegalArgumentException(
+                            "Tensor shapes=" + perTensorShapes + " were expected to match the input count=" + enforcedFirstDimension + " along either the first or second dimension, but does not.");
                 }
             } else {
                 //tensor case

--- a/explainability-service/src/main/java/org/kie/trustyai/service/payloads/data/upload/ModelInferRequestPayload.java
+++ b/explainability-service/src/main/java/org/kie/trustyai/service/payloads/data/upload/ModelInferRequestPayload.java
@@ -1,8 +1,8 @@
 package org.kie.trustyai.service.payloads.data.upload;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ModelInferRequestPayload extends ModelInferBasePayload {
     @JsonProperty("inputs")

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <version.com.fasterxml.jackson.databind>2.15.0</version.com.fasterxml.jackson.databind>
         <version.org.apache.commons.commons-lang3>3.18.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
-        <version.org.apache.opennlp>1.9.2</version.org.apache.opennlp>
+        <version.org.apache.opennlp>2.5.9</version.org.apache.opennlp>
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
         <version.org.junit.platform>1.9.0</version.org.junit.platform>
         <version.org.mockito>4.8.0</version.org.mockito>


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/trustyai-explainability/trustyai-explainability/blob/main/CONTRIBUTING.md)
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## Summary by Sourcery

Bump Apache OpenNLP dependency version and perform minor code style cleanups in KServe connector and service payload classes.

Enhancements:
- Apply minor formatting and import order adjustments in KServe V2 connector and model inference payload classes.

Build:
- Update Apache OpenNLP Maven dependency from 1.9.2 to 2.5.9.