### PR TITLE
Fix: Bump Jackson from 2.15.0 to 2.21.4

### DIFF
--- a/explainability-arrow/pom.xml
+++ b/explainability-arrow/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <version.org.apache.arrow>15.0.2</version.org.apache.arrow>
         <version.com.google.flatbuffers>2.0.3</version.com.google.flatbuffers>
-        <version.com.fasterxml.jackson.core>2.15.0</version.com.fasterxml.jackson.core> <!-- sync this with the databind version -->
+        <version.com.fasterxml.jackson.core>2.21.4</version.com.fasterxml.jackson.core> <!-- sync this with the databind version -->
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <version.org.slf4j>1.7.36</version.org.slf4j>
-        <version.com.fasterxml.jackson.databind>2.15.0</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.21.4</version.com.fasterxml.jackson.databind>
         <version.org.apache.commons.commons-lang3>3.18.0</version.org.apache.commons.commons-lang3>
         <version.org.apache.commons.commons-csv>1.9.0</version.org.apache.commons.commons-csv>
         <version.org.apache.opennlp>2.5.9</version.org.apache.opennlp>


### PR DESCRIPTION
## Summary

Bump `jackson-databind` and `jackson-core` from 2.15.0 to 2.21.4 to address three CVEs in the uber JAR bundled by the trustyai Python wheel.

## CVEs Addressed

| CVE | Package | Severity | Description |
|-----|---------|----------|-------------|
| CVE-2026-54512 | jackson-databind | **Critical** | Arbitrary code execution via PolymorphicTypeValidator bypass |
| CVE-2026-68494 | jackson-core | **High** | DoS via incomplete fix in async JSON parser |
| CVE-2026-50193 | jackson-databind | **Medium** | DoS via deeply nested JSON processing (StackOverflowError) |

## Changes

- `pom.xml`: `version.com.fasterxml.jackson.databind` 2.15.0 → 2.21.4
- `explainability-arrow/pom.xml`: `version.com.fasterxml.jackson.core` 2.15.0 → 2.21.4

## Context

The `explainability-arrow-*-SNAPSHOT.jar` is bundled inside the [trustyai Python wheel](https://pypi.org/project/trustyai/) and shipped in RHOAI Notebooks container images. The current jackson 2.15.0 (April 2023) is over 3 years old and flagged by security scanners across 33 Jira trackers in the RHOAI 3.3 release.

Red Hat has already published RHSA-2026:44064 shipping jackson 2.21.4 for RHEL 9.

This is similar to the recent opennlp bump in #709.

## After this merges

A new release of [trustyai-explainability-python](https://github.com/trustyai-explainability/trustyai-explainability-python) will be needed to rebuild the uber JAR with the updated Jackson and ship it on PyPI.

/cc @RobGeada @ruivieira